### PR TITLE
[ShortForm-Play]영상 재생안되는 현상 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.sean.ratel.android"
         minSdk = 28
         targetSdk = 34
-        versionCode = 10031
-        versionName = "1.0.3.1"
+        versionCode = 10032
+        versionName = "1.0.3.2"
         testInstrumentationRunner = "com.sean.ratel.android.HiltTestRunner"
         vectorDrawables {
             useSupportLibrary = true

--- a/app/src/main/java/com/sean/ratel/android/ui/end/YouTubeEndFragment.kt
+++ b/app/src/main/java/com/sean/ratel/android/ui/end/YouTubeEndFragment.kt
@@ -342,7 +342,7 @@ class YouTubeEndFragment(
 
         lifecycle.addObserver(youTubePlayerView)
 
-        youTubeStreamPlayer.initPlayer(networkHandle = false)
+        youTubeStreamPlayer.initPlayer(networkHandle = false, videoId = mainShortsModel?.shortsVideoModel?.videoId)
         youTubePlayerView.matchParent()
 
         return binding.root


### PR DESCRIPTION
7월 2일 갑자기 재생이 안되는 현상 발생
이슈는 추후 파악하고 초기 init 에 videoId 를 넣으면 일단 재생은 되어 배포 후 원인 분석이 필요하다.
- 플레이어 SDK 머지된 부분을 테스트가능하게 만드는 것이 중요할듯하다.